### PR TITLE
github-flavored-markdown dependency version increment

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Nodejitsu <info@nodejitsu.com>",
   "dependencies": {
     "async": "0.1.x",
-    "github-flavored-markdown": "0.1.x",
+    "github-flavored-markdown": "1.0.x",
     "traverse": "0.4.x",
     "mkdirp": "0.0.x",
     "http-server": "0.2.4",


### PR DESCRIPTION
github-flavored-markdown version 0.1.x isn't available in npm. I incremented the version to 1.0.x which is currently available. I've generated docs and all seems to be well on my local instance.
