### PR TITLE
Fix package.json link in /getting-started/npm/what-is-npm

### DIFF
--- a/articles/getting-started/npm/what-is-npm/article.md
+++ b/articles/getting-started/npm/what-is-npm/article.md
@@ -3,13 +3,13 @@
 
 Let's say you're hard at work one day, developing the Next Great Application.  You come across a problem, and you decide that it's time to use that cool library you keep hearing about - let's use Caolan McMahon's [async](http://github.com/caolan/async) as an example. Thankfully, `npm` is very simple to use: you only have to run `npm install async`, and the specified module will be installed in the current directory under `./node_modules/`.  Once installed to your `node_modules` folder, you'll be able to use `require()` on them just like they were built-ins.
 
-Let's look at an example of a global install - let's say `coffee-script`. The npm command is simple: `npm install coffee-script -g`. This will typically install the program and put a symlink to it in `/usr/local/bin/`.  This will then allow you to run the program from the console just like any other CLI tool.  In this case, running `coffee` will now allow you to use the coffee-script REPL. 
+Let's look at an example of a global install - let's say `coffee-script`. The npm command is simple: `npm install coffee-script -g`. This will typically install the program and put a symlink to it in `/usr/local/bin/`.  This will then allow you to run the program from the console just like any other CLI tool.  In this case, running `coffee` will now allow you to use the coffee-script REPL.
 
-Another important use for npm is dependency management.  When you have a node project with a [package.json](/what-is-the-file-package-json) file, you can run `npm install` from the project root and npm will install all the dependencies listed in the package.json. This makes installing a Node project from a git repo much easier! For example, `vows`, one of Node's testing frameworks, can be installed from git, and its single dependency, `eyes`, can be automatically handled:
+Another important use for npm is dependency management.  When you have a node project with a [package.json](/articles/getting-started/npm/what-is-the-file-package-json) file, you can run `npm install` from the project root and npm will install all the dependencies listed in the package.json. This makes installing a Node project from a git repo much easier! For example, `vows`, one of Node's testing frameworks, can be installed from git, and its single dependency, `eyes`, can be automatically handled:
 
 Example:
 
-    git https://github.com/cloudhead/vows.git
+    git clone https://github.com/cloudhead/vows.git
     cd vows
     npm install
 


### PR DESCRIPTION
from:
/what-is-the-file-package-json
to:
/articles/getting-started/npm/what-is-the-file-package-json

Also add 'clone' to code example:
git clone ...
