### PR TITLE
Update content.md

### DIFF
--- a/pages/articles/intermediate/how-to-log/content.md
+++ b/pages/articles/intermediate/how-to-log/content.md
@@ -17,7 +17,7 @@ Here is an example of a basic custom logging module with configurable debugging 
       var logger = exports;
       logger.debugLevel = 'warn';
       logger.log = function(level, message) {
-        var levels = ['error', 'warn', 'info'];
+        var levels = ['info', 'warn', 'error'];
         if (levels.indexOf(level) <= levels.indexOf(logger.debugLevel) ) {
           if (typeof message !== 'string') {
             message = JSON.stringify(message);


### PR DESCRIPTION
fix the indices of array levels ... from   [ 'error', 'warn','info']  to ['info', 'warn', 'error'] .. previous sort leads to show info level  or info/warn only or info/warn/error ... while it should be error only, or error/warn .. or error/warn/info ..