### PR TITLE
Added Comma to Sample Code

### DIFF
--- a/pages/articles/file-system/how-to-store-local-config-data/content.md
+++ b/pages/articles/file-system/how-to-store-local-config-data/content.md
@@ -7,7 +7,7 @@ Let's take a look at a very simple (and contrived) example.  First, to save some
 
       var myOptions = {
         name: 'Avian',
-        dessert: 'cake'
+        dessert: 'cake',
         flavor: 'chocolate',
         beverage: 'coffee'
       };


### PR DESCRIPTION
Missing comma after dessert value of myOptions so sample code would error if tried, added it in.

Before (Line 10):
 dessert: 'cake'

After (Line 10):
dessert: 'cake',